### PR TITLE
Document where cookie_name has to live

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ $ gem install rack-jwt
 
 * `verify` : optional : Boolean : Determines whether JWT will verify tokens keys for mismatch key types when decoded. Default is `true`. Set to `false` if you are using the `'none'` algorithm.
 
-* `cookie_name` : optional : String : If set, the middleware will fetch the token from the
-cookie with given name. The cookie's value should be set **without Bearer prefix**.
-
 * `options` : optional : Hash : A hash of options that are passed through to JWT to configure supported claims and algorithms. See the ruby-jwt docs for [more information of the algorithms and their requirements](https://github.com/jwt/ruby-jwt#algorithms-and-usage) as well as [more information on the supported claims](https://github.com/progrium/ruby-jwt#support-for-reserved-claim-names). These options are passed through without change to the underlying `ruby-jwt` gem. By default only expiration (exp) and Not Before (nbf) claims are verified. Pass in an algorithm choice like `{ algorithm: 'HS256' }`.
+
+* `options.cookie_name` : optional : String : If set, the middleware will fetch the token from the 
+cookie with given name. The cookie's value should be set **without Bearer prefix**. Currently this 
+must be set in the `options` hash.
 
 * `exclude` : optional : Array : An Array of path strings (with, optionally, http methods) representing paths that should not be checked for the presence of a valid JWT token. Excludes sub-paths as of specified paths as well (e.g. `%w(/docs)` excludes `/docs/some/thing.html` also). Each path should start with a `/`. Optionally, each path can be specified with http method, either `:all` or a select list of http methods, eg `[:get]`.  If a path (and http method if specified) matches the current request path (and http method), authentication and verification of token is not required, but a token will be parsed and verified if one is supplied.
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ $ gem install rack-jwt
 
 `Rack::JWT::Auth` accepts several configuration options. All options are passed in a single Ruby Hash:
 
-* `secret` : required : `String` || `OpenSSL::PKey::RSA` || `OpenSSL::PKey::EC` : A cryptographically secure String (for HMAC algorithms) or a public key object of an appropriate type for public key algorithms. Set to `nil` if you are using the `'none'` algorithm.
+* `secret` : required : `String` || `OpenSSL::PKey::RSA` || `OpenSSL::PKey::EC` : A cryptographically secure String (for HMAC algorithms) or a public key object of an appropriate type for public key algorithms. Set to `nil` if you are using the `'none'` algorithm or passing a `jwks` hash in `options`.
 
 * `verify` : optional : Boolean : Determines whether JWT will verify tokens keys for mismatch key types when decoded. Default is `true`. Set to `false` if you are using the `'none'` algorithm.
 
 * `cookie_name` : optional : String : If set, the middleware will fetch the token from the
 cookie with given name. The cookie's value should be set **without Bearer prefix**.
 
-* `options` : optional : Hash : A hash of options that are passed through to JWT to configure supported claims and algorithms. See the ruby-jwt docs for [more information of the algorithms and their requirements](https://github.com/jwt/ruby-jwt#algorithms-and-usage) as well as [more information on the supported claims](https://github.com/progrium/ruby-jwt#support-for-reserved-claim-names). These options are passed through without change to the underlying `ruby-jwt` gem. By default only expiration (exp) and Not Before (nbf) claims are verified. Pass in an algorithm choice like `{ algorithm: 'HS256' }`.
+* `options` : optional : Hash : A hash of options that are passed through to JWT to configure supported claims and algorithms. See the ruby-jwt docs for [more information of the algorithms and their requirements](https://github.com/jwt/ruby-jwt#algorithms-and-usage) as well as [more information on the supported claims](https://github.com/progrium/ruby-jwt#support-for-reserved-claim-names). These options are passed through without change to the underlying `ruby-jwt` gem. By default only expiration (exp) and Not Before (nbf) claims are verified. Pass in an algorithm choice like `{ algorithm: 'HS256' }`. You can pass in a `jwks` hash to have the JWT verified against a [JWKS list](https://github.com/jwt/ruby-jwt#json-web-key-jwk). 
 
 * `exclude` : optional : Array : An Array of path strings (with, optionally, http methods) representing paths that should not be checked for the presence of a valid JWT token. Excludes sub-paths as of specified paths as well (e.g. `%w(/docs)` excludes `/docs/some/thing.html` also). Each path should start with a `/`. Optionally, each path can be specified with http method, either `:all` or a select list of http methods, eg `[:get]`.  If a path (and http method if specified) matches the current request path (and http method), authentication and verification of token is not required, but a token will be parsed and verified if one is supplied.
 
@@ -114,6 +114,37 @@ alg = 'HS256'
 
 Rack::JWT::Token.encode(my_payload, secret, alg)
 ```
+
+### JWKS
+
+If you want to load your keys via JWKS, which is useful if you are using an asymmetric key and the private key is held by an identity server, you can do so.
+
+```ruby
+require 'net/http'
+require 'jwt'
+source = 'https://local.fusionauth.io/.well-known/jwks.json'
+resp = Net::HTTP.get_response(URI.parse(source))
+data = resp.body
+jwks_hash = JSON.parse(data)
+
+jwks = JWT::JWK::Set.new(jwks_hash)
+jwks.select! { |key| key[:use] == 'sig' } # Signing Keys only
+```
+
+Then, pass `jwks` like:
+
+```ruby
+jwt_auth_args = {
+  secret: nil,
+  options: {
+    jwks: jwks,
+    algorithm: 'RS256'
+  }
+}
+config.middleware.use Rack::JWT::Auth, jwt_auth_args
+```
+
+See https://github.com/jwt/ruby-jwt#json-web-key-jwk for more about loading and caching the JWKS keyset.
 
 ## Contributing
 

--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -134,8 +134,9 @@ module Rack
       def check_secret!
         return unless @secret.nil? || (@secret.is_a?(String) && @secret.empty?)
         return if @options[:algorithm] == 'none'
+        return if (!@options[:jwks].nil? && @options[:algorithm] == 'RS256')
 
-        raise ArgumentError, 'secret argument can only be nil/empty for the "none" algorithm'
+        raise ArgumentError, 'secret argument can only be nil/empty for the "none" algorithm or if you are using jwks'
       end
 
       def check_secret_and_verify_for_none_alg!

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -113,6 +113,30 @@ describe Rack::JWT::Auth do
           expect { Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
         end
       end
+
+      describe 'when algorithm "RS256" and secret is nil and verify is true and jwks is not provided' do
+        it 'raises an exception' do
+          expect { Rack::JWT::Auth.new(inner_app, secret: nil, verify: false, options: { algorithm: 'RS256' }) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'when algorithm "RS256" and secret is nil and verify is true and jwks is provided' do
+        let(:app) { Rack::JWT::Auth.new(inner_app, secret: nil, verify: false, options: { algorithm: 'RS256', jwks: {} }) }
+
+        it 'succeeds' do
+          header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+          get('/')
+          expect(last_response.status).to eq 200
+        end
+      end
+
+      describe 'when algorithm "HS256" and secret is nil and verify is true and jwks is provided' do
+        it 'raises an exception' do
+          expect { Rack::JWT::Auth.new(inner_app, secret: nil, verify: false, options: { algorithm: 'HS256' }) }.to raise_error(ArgumentError)
+        end
+      end
+
+
     end
 
     # see also exclusion_spec.rb


### PR DESCRIPTION
The `cookie_name` setting has to be in `options` otherwise it is not picked up. This is due to https://github.com/mindfulchefuk/rack-jwt/blob/master/lib/rack/jwt/auth.rb#L51 which looks at `options` not `opts`.